### PR TITLE
Type in kafka record header

### DIFF
--- a/Gateway/gateway.py
+++ b/Gateway/gateway.py
@@ -88,7 +88,7 @@ def place_offer():
                          offer['allow_partial_fill'])
 
     offer_to_producer = simplejson.dumps(placed_offer.__dict__, use_decimal=True)
-    offer_record_headers = ("type", bytearray('offer'))
+    offer_record_headers = [("type", bytes('offer', encoding='utf8'))]
 
     logging.info(offer_to_producer)
     logging.info("Using Producer instance to send the offer to Kafka topic 'offers' ")
@@ -142,7 +142,7 @@ def place_bid():
         placed_bid = Bid.Bid(next_id, bid['owner_id'], bid['bid_interest'], bid['target_offer_id'], bid['partial_only'])
 
     bid_to_producer = simplejson.dumps(placed_bid.__dict__, use_decimal=True)
-    bid_record_headers = ("type", bytearray('bid'))
+    bid_record_headers = [("type", bytes('bid', encoding='utf8'))]
 
     logging.info(bid_to_producer)
     logging.info("Using Producer instance to send the bid to Kafka topic 'bids' ")

--- a/Gateway/gateway.py
+++ b/Gateway/gateway.py
@@ -9,21 +9,22 @@ from credittomodels import Offer
 from producer_from_api import ProducerFromApi
 from credittomodels import statuses
 
-# 1. Add automated tests: match flow, API + SQL. Make tests to run in a separate container (e2e test)
+# 1. Add automated tests: match flow, API + SQL - D
 # 2. Add validation on Offer/Bid placement - respond only after confirmation  - P.D.
 # 3. Start writing read.me file (will be also considered as a spec) - D
 # 4. Matching logic - move to separate files, update existing - D
 # 5. Matching logic - move config to SQL (needed for tests) - D
 # 6. Add Cancel Bid flow (?)
 # 7. In SQL - make a list of authorized lenders and borrowers, verify each customer is limited to X offer/bids (?)
-# 8. Kafka messages - PROTOBUF (??)
+# 8. Kafka messages - PROTOBUF  - In Progress..
 # 9. Add API methods -  offers_by_status, get_my_bids (by CID) - D
 # 10. Offer - add 'matching bid' to SQL, on match creation update offer status in SQL - D
 # 11. Bid validation - add a new limitation: each lender can place only ONE bid on each offer.
 # 12. Offer - add property 'final_interest', add in package and in DB as well - D
 # 13. Consider adding Expirator/TimeManager service (?)
-# 14. Test framework - request must be printed and/or logged.
-
+# 14. Test framework - request must be printed and/or logged - D
+# 15. Add headers to Kafka records, message type should be in record header (VIP)
+# 16. Make tests to run in a separate container (e2e test)
 
 
 logging.basicConfig(level=logging.INFO)
@@ -87,10 +88,11 @@ def place_offer():
                          offer['allow_partial_fill'])
 
     offer_to_producer = simplejson.dumps(placed_offer.__dict__, use_decimal=True)
+    offer_record_headers = ("type", bytearray('offer'))
 
     logging.info(offer_to_producer)
     logging.info("Using Producer instance to send the offer to Kafka topic 'offers' ")
-    print(producer.produce_message(offer_to_producer, 'offers'))
+    print(producer.produce_message(offer_to_producer, 'offers', offer_record_headers))
 
     # Verifying placed offer was saved to 'offers' SQL table
     if not reporter.verify_offer_by_id(next_id):
@@ -140,10 +142,11 @@ def place_bid():
         placed_bid = Bid.Bid(next_id, bid['owner_id'], bid['bid_interest'], bid['target_offer_id'], bid['partial_only'])
 
     bid_to_producer = simplejson.dumps(placed_bid.__dict__, use_decimal=True)
+    bid_record_headers = ("type", bytearray('bid'))
 
     logging.info(bid_to_producer)
     logging.info("Using Producer instance to send the bid to Kafka topic 'bids' ")
-    print(producer.produce_message(bid_to_producer, 'bids'))
+    print(producer.produce_message(bid_to_producer, 'bids', bid_record_headers))
 
     return {"result": f"Added new bid, ID {next_id} assigned", "bid_id": next_id}
 

--- a/Gateway/producer_from_api.py
+++ b/Gateway/producer_from_api.py
@@ -15,8 +15,8 @@ from local_config import KafkaConfig
 class ProducerFromApi(object):
 
     def __init__(self):
-        self.producer = KafkaProducer(value_serializer = lambda m: json.dumps(m).encode('utf-8'),
-                                      bootstrap_servers = [KafkaConfig.BOOTSTRAP_SERVERS.value])
+        self.producer = KafkaProducer(value_serializer=lambda m: json.dumps(m).encode('utf-8'),
+                                      bootstrap_servers=[KafkaConfig.BOOTSTRAP_SERVERS.value])
 
     # headers (optional): a list of header key value pairs. List items
     #                 are tuples of str key and bytes value.

--- a/Gateway/producer_from_api.py
+++ b/Gateway/producer_from_api.py
@@ -18,10 +18,16 @@ class ProducerFromApi(object):
         self.producer = KafkaProducer(value_serializer = lambda m: json.dumps(m).encode('utf-8'),
                                       bootstrap_servers = [KafkaConfig.BOOTSTRAP_SERVERS.value])
 
+    # headers (optional): a list of header key value pairs. List items
+    #                 are tuples of str key and bytes value.
 
-    def produce_message(self, message, topic):
+    def produce_message(self, message, topic, headers=None):
         logging.info(f"ProducerFromApi: Producing message {message} to topic {topic}")
-        result = self.producer.send(topic, value=message)
+        if headers:
+            self.producer.send(topic, value=message, headers=headers)
+        else:
+            self.producer.send(topic, value=message)
+
         self.producer.flush()
         time.sleep(0.01)
         logging.info(f"ProducerFromApi: Succssfully produced message {message} to topic {topic}")

--- a/Matcher/consumer_to_matcher.py
+++ b/Matcher/consumer_to_matcher.py
@@ -53,11 +53,23 @@ class ConsumerToMatcher(object):
         self.consumer = KafkaConsumer('offers', 'bids', bootstrap_servers=[KafkaConfig.BOOTSTRAP_SERVERS.value],
                                     auto_offset_reset='earliest', enable_auto_commit=True, group_id="matcher_consumer")
 
+    def extract_message_type(self, kafka_message):
+        if kafka_message.headers is None or len(kafka_message.headers) < 1:
+            logging.warning("Matcher Consumer: Kafka message with no valid metadata, no message type in header")
+            return False
+
+        message_header = kafka_message.headers[0]
+        if message_header[0] == 'type':
+            return message_header[1].decode('utf-8')
+
+        else:
+            logging.warning("Matcher Consumer: No message type in header")
+            return False
+
     def consume_process(self):
         for msg in self.consumer:
 
-            message_header = msg.headers
-            logging.warning(message_header)
+            print(f"Extracted message type: {self.extract_message_type(msg)}")
 
             message_content = msg.value.decode('utf-8')
             object_content = simplejson.loads(simplejson.loads(message_content))

--- a/Matcher/consumer_to_matcher.py
+++ b/Matcher/consumer_to_matcher.py
@@ -71,12 +71,16 @@ class ConsumerToMatcher(object):
 
             print(f"Extracted message type: {self.extract_message_type(msg)}")
 
+            message_type = self.extract_message_type(msg)
+            if not message_type:
+                logging.warning("Matcher Consumer: Received a message with no valid type in headers, skipping.")
+
             message_content = msg.value.decode('utf-8')
             object_content = simplejson.loads(simplejson.loads(message_content))
             print(object_content)
             logging.info(f"ConsumerToSql: Received message {object_content}")
 
-            if object_content['type'] == statuses.Types.OFFER.value:
+            if message_type == statuses.Types.OFFER.value:
                 logging.info("ConsumerToMatcher: Processing OFFER")
 
                 received_offer = Offer.Offer(object_content['id'],
@@ -90,7 +94,7 @@ class ConsumerToMatcher(object):
 
                 self.matcher.add_offer(received_offer)
 
-            elif object_content['type'] == statuses.Types.BID.value:
+            elif message_type == statuses.Types.BID.value:
                 logging.info("ConsumerToMatcher: Processing BID")
 
                 received_bid = Bid.Bid(object_content['id'],

--- a/Matcher/consumer_to_matcher.py
+++ b/Matcher/consumer_to_matcher.py
@@ -55,6 +55,10 @@ class ConsumerToMatcher(object):
 
     def consume_process(self):
         for msg in self.consumer:
+
+            message_header = msg.headers
+            logging.warning(message_header)
+
             message_content = msg.value.decode('utf-8')
             object_content = simplejson.loads(simplejson.loads(message_content))
             print(object_content)

--- a/Matcher/matcher.py
+++ b/Matcher/matcher.py
@@ -70,10 +70,11 @@ class Matcher(object):
                 if isinstance(is_match, Match.Match):
                     self.matched_offer = offer
                     match_to_producer = simplejson.dumps(is_match.__dict__, use_decimal=True)
+                    match_record_headers = [("type", bytes('match', encoding='utf8'))]
 
                     logging.info(match_to_producer)
                     logging.info("MATCHER: Using Producer instance to send the match to Kafka topic 'matches' ")
-                    print(producer.produce_message(match_to_producer, 'matches'))
+                    print(producer.produce_message(match_to_producer, 'matches', match_record_headers))
 
         # Removing offer that was matched (if there was a match) and all bids on it from the pool
         if self.matched_offer:

--- a/Matcher/producer_from_matcher.py
+++ b/Matcher/producer_from_matcher.py
@@ -11,13 +11,16 @@ logging.basicConfig(level=logging.INFO)
 class ProducerFromMatcher(object):
 
     def __init__(self):
-        self.producer = KafkaProducer(value_serializer = lambda m: simplejson.dumps(m).encode('utf-8'),
-                                      bootstrap_servers = [KafkaConfig.BOOTSTRAP_SERVERS.value])
+        self.producer = KafkaProducer(value_serializer=lambda m: simplejson.dumps(m).encode('utf-8'),
+                                      bootstrap_servers=[KafkaConfig.BOOTSTRAP_SERVERS.value])
 
-
-    def produce_message(self, message, topic):
+    def produce_message(self, message, topic, headers=None):
         logging.info(f"ProducerFromApi: Producing message {message} to topic {topic}")
-        result = self.producer.send(topic, value=message)
+        if headers:
+            self.producer.send(topic, value=message, headers=headers)
+        else:
+            self.producer.send(topic, value=message)
+
         self.producer.flush()
         time.sleep(0.01)
         logging.info(f"ProducerFromApi: Succssfully produced message {message} to topic {topic}")

--- a/QaService/Tests/bid_placement_negative_test.py
+++ b/QaService/Tests/bid_placement_negative_test.py
@@ -79,6 +79,8 @@ class TestBidPlacement(object):
                 place_bid(self.bid_owners[i], self.bid_interest_list[i], self.offer_id, 0)
             logging.info(response)
 
+        time.sleep(5)
+
         response = postman.gateway_requests. \
             place_bid(self.bid_owners[i], self.bid_interest_list[i], self.offer_id, 0)
         logging.info(response)

--- a/QaService/config.ini
+++ b/QaService/config.ini
@@ -7,4 +7,4 @@ db_name : creditto
 
 [URL]
 base_url:http://127.0.0.1:5000/
-WAIT_BEFORE_TIMEOUT:10
+WAIT_BEFORE_TIMEOUT:20


### PR DESCRIPTION
'Type' is added to Bid, Offer and Match Kafka messages.
Using 'Type' the message type can be defined BEFORE the message is deserialized and handled accordingly. 